### PR TITLE
Parse docstring param descriptions into tool schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemurian"
-version = "1.0.0"
+version = "1.1.0"
 description = "A framework for building AI agents in Python"
 readme = "README.md"
 authors = [
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "docstring-parser>=0.16",
     "openai>=1.107.0",
     "pydantic>=2.11.7",
 ]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -4,6 +4,7 @@ from lemurian.tools import (
     Tool,
     ToolCallResult,
     _build_parameters_schema,
+    _parse_param_descriptions,
     tool,
 )
 
@@ -12,11 +13,10 @@ from lemurian.tools import (
 # Schema generation (_build_parameters_schema)
 # ---------------------------------------------------------------------------
 
+
 class TestBuildParametersSchema:
     def test_python_types_map_to_json_schema_types(self):
-        def func(
-            a: str, b: int, c: float, d: bool, e: list, f: dict
-        ):
+        def func(a: str, b: int, c: float, d: bool, e: list, f: dict):
             pass
 
         schema, _ = _build_parameters_schema(func)
@@ -51,8 +51,187 @@ class TestBuildParametersSchema:
 
 
 # ---------------------------------------------------------------------------
+# Docstring param description parsing (_parse_param_descriptions)
+# ---------------------------------------------------------------------------
+
+
+class TestParseParamDescriptions:
+    def test_google_style(self):
+        def func(name: str, age: int):
+            """Do something.
+
+            Args:
+                name: The user's name.
+                age: The user's age.
+            """
+
+        descs = _parse_param_descriptions(func)
+        assert descs == {
+            "name": "The user's name.",
+            "age": "The user's age.",
+        }
+
+    def test_google_style_with_type_in_docstring(self):
+        def func(name, age):
+            """Do something.
+
+            Args:
+                name (str): The user's name.
+                age (int): The user's age.
+            """
+
+        descs = _parse_param_descriptions(func)
+        assert descs == {
+            "name": "The user's name.",
+            "age": "The user's age.",
+        }
+
+    def test_sphinx_rest_style(self):
+        def func(name: str, age: int):
+            """Do something.
+
+            :param name: The user's name.
+            :param age: The user's age.
+            """
+
+        descs = _parse_param_descriptions(func)
+        assert descs == {
+            "name": "The user's name.",
+            "age": "The user's age.",
+        }
+
+    def test_numpy_style(self):
+        def func(name: str, age: int):
+            """Do something.
+
+            Parameters
+            ----------
+            name : str
+                The user's name.
+            age : int
+                The user's age.
+            """
+
+        descs = _parse_param_descriptions(func)
+        assert descs == {
+            "name": "The user's name.",
+            "age": "The user's age.",
+        }
+
+    def test_no_docstring(self):
+        def func(x: str):
+            pass
+
+        assert _parse_param_descriptions(func) == {}
+
+    def test_docstring_without_params_section(self):
+        def func(x: str):
+            """Just a summary."""
+
+        assert _parse_param_descriptions(func) == {}
+
+    def test_multiline_description(self):
+        def func(query: str):
+            """Search.
+
+            Args:
+                query: The search query string.
+                    Supports boolean operators
+                    and wildcards.
+            """
+
+        descs = _parse_param_descriptions(func)
+        assert descs == {
+            "query": (
+                "The search query string.\n"
+                "Supports boolean operators\n"
+                "and wildcards."
+            ),
+        }
+
+    def test_context_param_in_docstring_ignored_by_schema(self):
+        """Documented context param doesn't leak into the schema."""
+
+        def func(context, query: str):
+            """Search.
+
+            Args:
+                context: The runtime context.
+                query: The search query.
+            """
+
+        schema, _ = _build_parameters_schema(func)
+        assert "context" not in schema["properties"]
+        assert schema["properties"]["query"]["description"] == (
+            "The search query."
+        )
+
+    def test_undocumented_param_gets_empty_description(self):
+        def func(a: str, b: int):
+            """Do something.
+
+            Args:
+                a: Documented param.
+            """
+
+        schema, _ = _build_parameters_schema(func)
+        assert schema["properties"]["a"]["description"] == (
+            "Documented param."
+        )
+        assert schema["properties"]["b"]["description"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Param descriptions flow through to @tool schema
+# ---------------------------------------------------------------------------
+
+
+class TestToolParamDescriptions:
+    def test_google_descriptions_in_tool_schema(self):
+        @tool
+        def search(query: str, max_results: int = 10):
+            """Search the knowledge base.
+
+            Args:
+                query: The search query string.
+                max_results: Maximum results to return.
+            """
+
+        schema = search.model_dump()
+        params = schema["function"]["parameters"]["properties"]
+        assert params["query"]["description"] == ("The search query string.")
+        assert params["max_results"]["description"] == (
+            "Maximum results to return."
+        )
+
+    def test_rest_descriptions_in_tool_schema(self):
+        @tool
+        def lookup(user_id: int):
+            """Look up a user.
+
+            :param user_id: The ID of the user to look up.
+            """
+
+        schema = lookup.model_dump()
+        params = schema["function"]["parameters"]["properties"]
+        assert params["user_id"]["description"] == (
+            "The ID of the user to look up."
+        )
+
+    def test_no_params_section_still_works(self):
+        @tool
+        def greet(name: str):
+            """Say hello."""
+
+        schema = greet.model_dump()
+        params = schema["function"]["parameters"]["properties"]
+        assert params["name"]["description"] == ""
+
+
+# ---------------------------------------------------------------------------
 # @tool decorator — two code paths
 # ---------------------------------------------------------------------------
+
 
 class TestToolDecorator:
     def test_bare_decorator(self):
@@ -78,6 +257,7 @@ class TestToolDecorator:
 # ---------------------------------------------------------------------------
 # Tool.model_dump — OpenAI-compatible schema
 # ---------------------------------------------------------------------------
+
 
 def test_tool_model_dump_openai_format():
     @tool
@@ -105,6 +285,7 @@ def test_tool_model_dump_openai_format():
 # ---------------------------------------------------------------------------
 # Tool.__call__ — sync/async dispatch and output type
 # ---------------------------------------------------------------------------
+
 
 class TestToolCall:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -510,6 +510,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -997,9 +1006,10 @@ wheels = [
 
 [[package]]
 name = "lemurian"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "docstring-parser" },
     { name = "openai" },
     { name = "pydantic" },
 ]
@@ -1021,6 +1031,7 @@ modal = [
 
 [package.metadata]
 requires-dist = [
+    { name = "docstring-parser", specifier = ">=0.16" },
     { name = "openai", specifier = ">=1.107.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]


### PR DESCRIPTION
* Use docstring_parser with auto-detection to extract parameter descriptions from Google, NumPy, Sphinx/reST, and Epydoc style docstrings into the JSON schema passed to LLMs, improving tool-calling accuracy.
* Falls back to empty string for undocumented params or missing docstrings.
* Bump version to 1.1.0.

https://claude.ai/code/session_015wrRu97CZ6ccCLRDYBpP93