### PR TITLE
Add OpenAICompatibleProvider and LiteLLMProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 **Swarm** — Multi-agent orchestrator. Creates a dynamic `handoff` tool with an enum of available agents. Fresh-context handoffs: each agent sees only the handoff message onward.
 
-**Provider** — Abstraction over LLM APIs. Implementations for OpenAI, OpenRouter, local vLLM, and Modal vLLM.
+**Provider** — Abstraction over LLM APIs. Implementations for OpenAI, OpenRouter, local vLLM, Modal vLLM, any OpenAI-compatible endpoint, and 100+ providers via LiteLLM.
 
 ## Defining Tools
 
@@ -208,6 +208,55 @@ Customize deployments with environment variables:
 Pre-download model weights for faster cold starts:
 ```bash
 modal run examples/modal_vllm.py --download
+```
+
+### Any OpenAI-Compatible Server
+
+Works with Ollama, Together, Groq, Fireworks, LM Studio, or any server with an OpenAI-compatible `/chat/completions` endpoint:
+
+```python
+from lemurian.provider import OpenAICompatibleProvider
+
+# Ollama
+provider = OpenAICompatibleProvider(
+    base_url="http://localhost:11434/v1"
+)
+
+# Together AI
+provider = OpenAICompatibleProvider(
+    base_url="https://api.together.xyz/v1",
+    api_key="your-together-key",
+)
+
+# Groq
+provider = OpenAICompatibleProvider(
+    base_url="https://api.groq.com/openai/v1",
+    api_key="your-groq-key",
+)
+```
+
+### LiteLLM (100+ Providers)
+
+Access Anthropic, Gemini, Cohere, Bedrock, Mistral, Azure, and [100+ other providers](https://docs.litellm.ai/docs/providers) through LiteLLM. Install it separately:
+
+```bash
+pip install litellm
+# or: uv sync --group litellm
+```
+
+```python
+from lemurian.provider import LiteLLMProvider
+
+# Anthropic
+provider = LiteLLMProvider()  # uses ANTHROPIC_API_KEY env var
+agent = Agent(..., model="anthropic/claude-sonnet-4-20250514", provider=provider)
+
+# Google Gemini
+provider = LiteLLMProvider()  # uses GEMINI_API_KEY env var
+agent = Agent(..., model="gemini/gemini-2.0-flash", provider=provider)
+
+# Explicit API key
+provider = LiteLLMProvider(api_key="sk-...")
 ```
 
 ## Testing

--- a/docs/design/provider-expansion.md
+++ b/docs/design/provider-expansion.md
@@ -1,0 +1,338 @@
+# Provider Expansion
+
+Add two new `ModelProvider` subclasses — `OpenAICompatibleProvider` and `LiteLLMProvider` — to cover the long tail of LLM endpoints without modifying existing providers.
+
+## Goals
+
+- Let users connect **any OpenAI-compatible endpoint** (Ollama, Together, Groq, Fireworks, LM Studio, vLLM, TGI) with a single `base_url`.
+- Let users connect **non-OpenAI providers** (Anthropic, Gemini, Cohere, Bedrock, 100+ others) via LiteLLM as an optional dependency.
+- Both `complete()` and `structured_completion()` work out of the box on both new providers.
+- Zero new required dependencies. LiteLLM is optional and lazy-imported.
+
+## Non-Goals
+
+- **Streaming.** The `ModelProvider` ABC and `Runner` have no streaming path today. Streaming is additive (new methods) and orthogonal to this work.
+- **Replacing existing providers.** `OpenAIProvider`, `OpenRouter`, `VLLMProvider`, and `ModalVLLMProvider` have provider-specific optimizations (Responses API, guided decoding) that a generic provider cannot replicate. They stay as-is.
+- **Direct Anthropic/Gemini SDKs.** First-class wrappers around individual non-OpenAI SDKs are high-maintenance for a project this size. LiteLLM covers these providers without per-SDK code.
+- **LiteLLM proxy server mode.** Only the Python SDK (`litellm.acompletion`) is used. The proxy/gateway deployment is out of scope.
+
+## Overall Design
+
+```mermaid
+classDiagram
+    class ModelProvider {
+        <<abstract>>
+        +complete(model, messages, tools) message
+        +structured_completion(model, messages, response_model) parsed
+    }
+
+    class OpenAIProvider {
+        -client: AsyncOpenAI
+        Uses Responses API for structured output
+    }
+
+    class OpenRouter {
+        -client: AsyncOpenAI
+        Uses Responses API for structured output
+    }
+
+    class VLLMProvider {
+        -client: AsyncOpenAI
+        Uses guided decoding (outlines)
+    }
+
+    class ModalVLLMProvider {
+        -client: AsyncOpenAI
+        Uses guided decoding (outlines)
+    }
+
+    class OpenAICompatibleProvider {
+        -client: AsyncOpenAI
+        Uses json_schema response_format
+    }
+
+    class LiteLLMProvider {
+        -_litellm: module
+        -_kwargs: dict
+        Uses json_schema response_format via LiteLLM
+    }
+
+    ModelProvider <|-- OpenAIProvider
+    ModelProvider <|-- OpenRouter
+    ModelProvider <|-- VLLMProvider
+    ModelProvider <|-- ModalVLLMProvider
+    ModelProvider <|-- OpenAICompatibleProvider
+    ModelProvider <|-- LiteLLMProvider
+```
+
+## Structured Output Strategy
+
+Each provider uses the structured output mechanism best suited to its backend. The key design question is how `structured_completion()` enforces JSON conforming to a Pydantic schema.
+
+```mermaid
+flowchart TD
+    A[structured_completion called] --> B{Which provider?}
+
+    B -->|OpenAIProvider / OpenRouter| C[Responses API]
+    C --> C1["client.responses.parse(text_format=Model)"]
+    C1 --> C2[return response.output_parsed]
+
+    B -->|VLLMProvider / ModalVLLMProvider| D[Guided Decoding]
+    D --> D1["client.beta.chat.completions.parse(response_format=Model)"]
+    D1 --> D2["extra_body={guided_decoding_backend: outlines}"]
+    D2 --> D3[return response.output_parsed]
+
+    B -->|OpenAICompatibleProvider| E[json_schema response_format]
+    E --> E1["Build response_format dict from Model.model_json_schema()"]
+    E1 --> E2["client.chat.completions.create(response_format=...)"]
+    E2 --> E3["Model.model_validate_json(content)"]
+
+    B -->|LiteLLMProvider| F[json_schema via LiteLLM]
+    F --> F1["Build response_format dict from Model.model_json_schema()"]
+    F1 --> F2["litellm.acompletion(response_format=...)"]
+    F2 --> F3["Model.model_validate_json(content)"]
+```
+
+The new providers both use the `json_schema` `response_format` approach — the most universally supported method across OpenAI-compatible servers and LiteLLM's 100+ provider translations.
+
+## Component: `OpenAICompatibleProvider`
+
+Wraps `AsyncOpenAI` pointed at an arbitrary `base_url`. No URL auto-manipulation, no provider-specific assumptions.
+
+```mermaid
+flowchart LR
+    User["User code"] -->|"base_url, api_key"| OCP[OpenAICompatibleProvider]
+    OCP -->|AsyncOpenAI| EP["Any OpenAI-compat endpoint"]
+    EP --- Ollama & Together & Groq & Fireworks & LMStudio & vLLM & TGI
+```
+
+```python
+class OpenAICompatibleProvider(ModelProvider):
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout: float = 300.0,
+        max_retries: int = 3,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.client = AsyncOpenAI(
+            base_url=self.base_url,
+            api_key=api_key or "DUMMY",
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    async def complete(self, model, messages, tools=None):
+        kwargs = {"model": model, "messages": messages}
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        resp = await self.client.chat.completions.create(
+            **kwargs
+        )
+        return resp.choices[0].message
+
+    async def structured_completion(
+        self, model, messages, response_model,
+    ):
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": response_model.model_json_schema(),
+                "name": response_model.__name__,
+                "strict": True,
+            },
+        }
+        resp = await self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            response_format=response_format,
+        )
+        return response_model.model_validate_json(
+            resp.choices[0].message.content
+        )
+```
+
+Design decisions:
+- **No `/v1` auto-append** — unlike `ModalVLLMProvider`, a generic provider must accept arbitrary URLs. Ollama uses `/v1`, some servers don't.
+- **`api_key` defaults to `"DUMMY"`** — local servers don't need auth, but `AsyncOpenAI` requires a non-empty key.
+- **`tool_choice` only with tools** — follows `ModalVLLMProvider` pattern. Some servers reject `tool_choice` without tools.
+- **`json_schema` for structured output** — most universally supported. No dependency on `beta.chat.completions.parse()` which many compat servers lack.
+
+## Component: `LiteLLMProvider`
+
+Delegates to `litellm.acompletion()`. LiteLLM translates OpenAI-format requests to each provider's native API.
+
+```mermaid
+flowchart LR
+    User["User code"] -->|"model string"| LP[LiteLLMProvider]
+    LP -->|"litellm.acompletion()"| LiteLLM["LiteLLM SDK"]
+    LiteLLM -->|translates| Anthropic & Gemini & Cohere & Bedrock & Mistral & Azure
+```
+
+```python
+class LiteLLMProvider(ModelProvider):
+
+    def __init__(self, api_key=None, **kwargs):
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "LiteLLMProvider requires 'litellm'. "
+                "Install: pip install litellm"
+            )
+        self._litellm = litellm
+        self.api_key = api_key
+        self._kwargs = kwargs
+
+    async def complete(self, model, messages, tools=None):
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            **self._kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        resp = await self._litellm.acompletion(**kwargs)
+        return resp.choices[0].message
+
+    async def structured_completion(
+        self, model, messages, response_model,
+    ):
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": response_model.model_json_schema(),
+                "name": response_model.__name__,
+                "strict": True,
+            },
+        }
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "response_format": response_format,
+            **self._kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        resp = await self._litellm.acompletion(**kwargs)
+        return response_model.model_validate_json(
+            resp.choices[0].message.content
+        )
+```
+
+Design decisions:
+- **Lazy import** — `litellm` is heavy (~50 transitive deps). Only imported when `LiteLLMProvider` is instantiated. Keeps `from lemurian.provider import OpenAIProvider` fast.
+- **`**kwargs` passthrough** — LiteLLM supports many provider-specific params (`api_base`, `timeout`, `max_retries`, custom headers). Rather than enumerating them, constructor kwargs are spread into every `acompletion` call.
+- **`json_schema` response_format** — LiteLLM supports this natively across OpenAI, Anthropic, Gemini, Ollama, LM Studio, Cohere, and more. Building the dict from `model_json_schema()` is more reliable than passing the Pydantic class directly (LiteLLM's internal conversion has known issues with required vs optional fields).
+- **Model routing via string** — LiteLLM uses `"provider/model"` format (e.g. `"anthropic/claude-sonnet-4-20250514"`, `"gemini/gemini-2.0-flash"`). No lemurian code needed for routing.
+
+## Data Flow: Agent with `OpenAICompatibleProvider` (Ollama)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Runner
+    participant Agent
+    participant OCP as OpenAICompatibleProvider
+    participant Ollama as Ollama localhost:11434
+
+    User->>Runner: run(agent, session, state)
+    Runner->>Runner: Build messages from transcript
+    Runner->>Agent: agent.provider.complete(model, messages, tools)
+    Agent->>OCP: complete("llama3.1", messages, tools)
+    OCP->>OCP: Build kwargs, add tool_choice if tools
+    OCP->>Ollama: POST /v1/chat/completions
+    Ollama-->>OCP: {choices: [{message: {...}}]}
+    OCP-->>Runner: choices[0].message
+    Runner->>Runner: Process tool calls or return result
+    Runner-->>User: RunResult
+```
+
+## Data Flow: Structured Output with `LiteLLMProvider` (Anthropic)
+
+```mermaid
+sequenceDiagram
+    participant Runner
+    participant LP as LiteLLMProvider
+    participant LiteLLM as litellm SDK
+    participant Claude as Anthropic API
+
+    Runner->>LP: structured_completion("anthropic/claude-sonnet-4-20250514", msgs, MyModel)
+    LP->>LP: Build response_format from MyModel.model_json_schema()
+    LP->>LiteLLM: acompletion(model, msgs, response_format={type: json_schema, ...})
+    LiteLLM->>LiteLLM: Translate to Anthropic message format
+    LiteLLM->>Claude: POST /v1/messages (native Anthropic format)
+    Claude-->>LiteLLM: Anthropic response with JSON content
+    LiteLLM->>LiteLLM: Translate back to OpenAI format
+    LiteLLM-->>LP: {choices: [{message: {content: '{"field": "value"}'}}]}
+    LP->>LP: MyModel.model_validate_json(content)
+    LP-->>Runner: Parsed MyModel instance
+```
+
+## Data Flow: Multi-Agent Swarm with Mixed Providers
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Swarm
+    participant Runner
+    participant Triage as triage agent<br/>(OpenAIProvider)
+    participant Worker as worker agent<br/>(LiteLLMProvider)
+    participant OpenAI as OpenAI API
+    participant Gemini as Google Gemini
+
+    User->>Swarm: run("route this task", agent="triage")
+    Swarm->>Runner: run(triage, session, state)
+    Runner->>Triage: complete("gpt-4o", messages, [handoff tool])
+    Triage->>OpenAI: POST /v1/chat/completions
+    OpenAI-->>Triage: handoff(agent_name="worker", message="...")
+    Triage-->>Runner: tool_call: handoff → worker
+    Runner-->>Swarm: RunResult(hand_off=worker)
+
+    Swarm->>Runner: run(worker, session, state)
+    Runner->>Worker: complete("gemini/gemini-2.0-flash", messages, tools)
+    Worker->>Gemini: (via litellm.acompletion)
+    Gemini-->>Worker: response
+    Worker-->>Runner: choices[0].message
+    Runner-->>Swarm: RunResult
+    Swarm-->>User: Final result
+```
+
+## Dependency Graph
+
+```mermaid
+flowchart BT
+    subgraph "Always installed"
+        openai["openai SDK"]
+        pydantic["pydantic"]
+    end
+
+    subgraph "Optional: uv sync --group litellm"
+        litellm["litellm"]
+    end
+
+    OAI[OpenAIProvider] --> openai
+    OR[OpenRouter] --> openai
+    VLLM[VLLMProvider] --> openai
+    Modal[ModalVLLMProvider] --> openai
+    OCP[OpenAICompatibleProvider] --> openai
+    LP[LiteLLMProvider] -.->|lazy import| litellm
+
+    OCP --> pydantic
+    LP --> pydantic
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/lemurian/provider.py` | Add `OpenAICompatibleProvider` and `LiteLLMProvider`. Normalize `tool_choice` handling: fix `VLLMProvider` bug (unconditional `tool_choice` without tools), make `OpenAIProvider` and `OpenRouter` explicit (`tool_choice: "auto"` when tools present). |
+| `pyproject.toml` | Add `litellm` dependency group |
+| `tests/unit/test_provider.py` | Tests for both new providers; update `VLLMProvider` test to assert corrected behavior |
+| `README.md` | Usage examples under Model Providers |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemurian"
-version = "1.2.0"
+version = "1.3.0"
 description = "A framework for building AI agents in Python"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ local = [
 modal = [
     "modal>=0.73.0",
 ]
+litellm = [
+    "litellm>=1.67.0",
+]
 docs = [
     "zensical",
     "mkdocstrings[python]>=0.29",

--- a/src/lemurian/provider.py
+++ b/src/lemurian/provider.py
@@ -109,6 +109,7 @@ class OpenAIProvider(ModelProvider):
         }
         if tools:
             kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
         response = await self.client.chat.completions.create(**kwargs)
         msg = response.choices[0].message
         return CompletionResult(
@@ -165,6 +166,7 @@ class OpenRouter(ModelProvider):
         }
         if tools:
             kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
         response = await self.client.chat.completions.create(**kwargs)
         msg = response.choices[0].message
         return CompletionResult(
@@ -211,10 +213,10 @@ class VLLMProvider(ModelProvider):
         kwargs: dict = {
             "model": model,
             "messages": messages,
-            "tool_choice": "auto",
         }
         if tools:
             kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
         response = await self.client.chat.completions.create(**kwargs)
         msg = response.choices[0].message
         return CompletionResult(
@@ -315,3 +317,158 @@ class ModalVLLMProvider(ModelProvider):
             extra_body=dict(guided_decoding_backend="outlines"),
         )
         return response.output_parsed  # type: ignore[attr-defined]
+
+
+class OpenAICompatibleProvider(ModelProvider):
+    """Provider for any OpenAI-compatible endpoint.
+
+    Works with Ollama, Together, Groq, Fireworks, LM Studio, vLLM,
+    TGI, and any server that implements the ``/chat/completions``
+    endpoint.
+
+    Args:
+        base_url: Full base URL of the endpoint
+            (e.g. ``"http://localhost:11434/v1"``).
+        api_key: Optional API key. Defaults to ``"DUMMY"`` for
+            local servers that don't require auth.
+        timeout: Request timeout in seconds.
+        max_retries: Maximum retries for failed requests.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout: float = 300.0,
+        max_retries: int = 3,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.client = AsyncOpenAI(
+            base_url=self.base_url,
+            api_key=api_key or "DUMMY",
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    async def complete(
+            self,
+            model: str,
+            messages: list[dict],
+            tools: list[dict] | None = None,
+    ):
+        kwargs: dict = {
+            "model": model,
+            "messages": messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        response = await self.client.chat.completions.create(**kwargs)
+        return response.choices[0].message
+
+    async def structured_completion(
+            self,
+            model: str,
+            messages: list[dict],
+            response_model: BaseModel,
+    ):
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": response_model.model_json_schema(),
+                "name": response_model.__name__,  # type: ignore[attr-defined]  # always a class at runtime
+                "strict": True,
+            },
+        }
+        response = await self.client.chat.completions.create(
+            model=model,
+            messages=messages,  # type: ignore[arg-type]  # OpenAI SDK overloaded unions
+            response_format=response_format,  # type: ignore[arg-type]  # raw dict accepted at runtime
+        )
+        return response_model.model_validate_json(
+            response.choices[0].message.content
+        )
+
+
+class LiteLLMProvider(ModelProvider):
+    """Provider that delegates to LiteLLM for 100+ LLM APIs.
+
+    Supports Anthropic, Gemini, Cohere, Bedrock, Mistral, Azure,
+    and any other provider that LiteLLM supports. Uses
+    ``litellm.acompletion()`` under the hood.
+
+    LiteLLM is **not** a required dependency — it is imported lazily
+    when this provider is instantiated. Install it separately::
+
+        pip install litellm
+
+    Model names use LiteLLM's ``"provider/model"`` format, e.g.
+    ``"anthropic/claude-sonnet-4-20250514"`` or
+    ``"gemini/gemini-2.0-flash"``.
+
+    Args:
+        api_key: Optional API key passed to every ``acompletion``
+            call. Provider-specific env vars (e.g.
+            ``ANTHROPIC_API_KEY``) also work.
+        **kwargs: Extra keyword arguments forwarded to every
+            ``litellm.acompletion`` call (e.g. ``api_base``,
+            ``timeout``, ``max_retries``).
+    """
+
+    def __init__(self, api_key: str | None = None, **kwargs):
+        try:
+            import litellm  # type: ignore[unresolved-import]  # optional dependency
+        except ImportError:
+            raise ImportError(
+                "LiteLLMProvider requires 'litellm'. "
+                "Install: pip install litellm"
+            )
+        self._litellm = litellm
+        self.api_key = api_key
+        self._kwargs = kwargs
+
+    async def complete(
+            self,
+            model: str,
+            messages: list[dict],
+            tools: list[dict] | None = None,
+    ):
+        kwargs: dict = {
+            "model": model,
+            "messages": messages,
+            **self._kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        response = await self._litellm.acompletion(**kwargs)
+        return response.choices[0].message
+
+    async def structured_completion(
+            self,
+            model: str,
+            messages: list[dict],
+            response_model: BaseModel,
+    ):
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": response_model.model_json_schema(),
+                "name": response_model.__name__,  # type: ignore[attr-defined]  # always a class at runtime
+                "strict": True,
+            },
+        }
+        kwargs: dict = {
+            "model": model,
+            "messages": messages,
+            "response_format": response_format,
+            **self._kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        response = await self._litellm.acompletion(**kwargs)
+        return response_model.model_validate_json(
+            response.choices[0].message.content
+        )

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,10 +1,13 @@
 from dataclasses import dataclass, field
+from types import ModuleType
 from unittest.mock import AsyncMock
 
 import pytest
 
 from lemurian.provider import (
+    LiteLLMProvider,
     ModalVLLMProvider,
+    OpenAICompatibleProvider,
     OpenAIProvider,
     OpenRouter,
     VLLMProvider,
@@ -80,10 +83,10 @@ def test_openai_provider_reads_env(monkeypatch):
 
 class TestOpenAIProviderComplete:
     @pytest.mark.asyncio
-    async def test_forwards_model_messages_and_tools(
+    async def test_forwards_tools_with_tool_choice(
         self, monkeypatch
     ):
-        """complete() passes model, messages, and tools through."""
+        """complete() passes tools and tool_choice='auto' together."""
         provider = OpenAIProvider(api_key="test-key")
         mock_create = AsyncMock(
             return_value=_fake_completion("hello")
@@ -100,13 +103,17 @@ class TestOpenAIProviderComplete:
         )
 
         mock_create.assert_called_once_with(
-            model="gpt-4o", messages=messages, tools=tools,
+            model="gpt-4o", messages=messages,
+            tools=tools, tool_choice="auto",
         )
         assert result.content == "hello"
 
     @pytest.mark.asyncio
-    async def test_omits_tools_key_when_none(self, monkeypatch):
-        """When tools is None, the 'tools' key is not sent."""
+    async def test_omits_tools_and_tool_choice_when_none(
+        self, monkeypatch
+    ):
+        """When tools is None, neither 'tools' nor 'tool_choice' is
+        sent."""
         provider = OpenAIProvider(api_key="test-key")
         mock_create = AsyncMock(
             return_value=_fake_completion("hi")
@@ -123,6 +130,7 @@ class TestOpenAIProviderComplete:
 
         _, kwargs = mock_create.call_args
         assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
 
     @pytest.mark.asyncio
     async def test_returns_message_from_first_choice(
@@ -143,15 +151,15 @@ class TestOpenAIProviderComplete:
 
 
 # ---------------------------------------------------------------------------
-# VLLMProvider.complete — always sends tool_choice
+# VLLMProvider.complete — conditional tool_choice (bug fix)
 # ---------------------------------------------------------------------------
 
 class TestVLLMProviderComplete:
     @pytest.mark.asyncio
-    async def test_always_includes_tool_choice_auto(
+    async def test_omits_tool_choice_without_tools(
         self, monkeypatch
     ):
-        """VLLMProvider always sends tool_choice='auto'."""
+        """VLLMProvider omits tool_choice when no tools are provided."""
         provider = VLLMProvider(url="localhost", port=8000)
         mock_create = AsyncMock(
             return_value=_fake_completion("ok")
@@ -164,6 +172,28 @@ class TestVLLMProviderComplete:
         await provider.complete("llama", [], tools=None)
 
         _, kwargs = mock_create.call_args
+        assert "tool_choice" not in kwargs
+        assert "tools" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_includes_tool_choice_with_tools(
+        self, monkeypatch
+    ):
+        """VLLMProvider sends tool_choice='auto' when tools present."""
+        provider = VLLMProvider(url="localhost", port=8000)
+        mock_create = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        monkeypatch.setattr(
+            provider.client.chat.completions, "create",
+            mock_create,
+        )
+
+        tools = [{"type": "function", "function": {"name": "f"}}]
+        await provider.complete("llama", [], tools=tools)
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
 
 
@@ -208,10 +238,10 @@ class TestModalVLLMProviderComplete:
 
 class TestOpenRouterComplete:
     @pytest.mark.asyncio
-    async def test_forwards_tools_and_omits_when_none(
+    async def test_forwards_tools_with_tool_choice(
         self, monkeypatch
     ):
-        """OpenRouter follows the same tools-forwarding contract."""
+        """OpenRouter sends tool_choice='auto' when tools present."""
         provider = OpenRouter(api_key="test-key")
         mock_create = AsyncMock(
             return_value=_fake_completion("hi")
@@ -221,15 +251,256 @@ class TestOpenRouterComplete:
             mock_create,
         )
 
-        # With tools
         tools = [{"type": "function", "function": {"name": "f"}}]
         await provider.complete("model", [], tools=tools)
         _, kwargs = mock_create.call_args
         assert kwargs["tools"] == tools
+        assert kwargs["tool_choice"] == "auto"
 
-        mock_create.reset_mock()
+    @pytest.mark.asyncio
+    async def test_omits_tools_and_tool_choice_when_none(
+        self, monkeypatch
+    ):
+        """OpenRouter omits tools and tool_choice when tools=None."""
+        provider = OpenRouter(api_key="test-key")
+        mock_create = AsyncMock(
+            return_value=_fake_completion("hi")
+        )
+        monkeypatch.setattr(
+            provider.client.chat.completions, "create",
+            mock_create,
+        )
 
-        # Without tools
         await provider.complete("model", [], tools=None)
         _, kwargs = mock_create.call_args
         assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# OpenAICompatibleProvider
+# ---------------------------------------------------------------------------
+
+class TestOpenAICompatibleProvider:
+    def test_strips_trailing_slash(self):
+        p = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1/"
+        )
+        assert p.base_url == "http://localhost:11434/v1"
+
+    def test_defaults_api_key_to_dummy(self):
+        p = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1"
+        )
+        assert p.client.api_key == "DUMMY"
+
+    def test_uses_provided_api_key(self):
+        p = OpenAICompatibleProvider(
+            base_url="http://localhost/v1",
+            api_key="real-key",
+        )
+        assert p.client.api_key == "real-key"
+
+    @pytest.mark.asyncio
+    async def test_complete_with_tools(self, monkeypatch):
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1"
+        )
+        mock_create = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        monkeypatch.setattr(
+            provider.client.chat.completions, "create",
+            mock_create,
+        )
+
+        tools = [{"type": "function", "function": {"name": "f"}}]
+        result = await provider.complete("llama3", [], tools=tools)
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["tools"] == tools
+        assert kwargs["tool_choice"] == "auto"
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_complete_without_tools(self, monkeypatch):
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1"
+        )
+        mock_create = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        monkeypatch.setattr(
+            provider.client.chat.completions, "create",
+            mock_create,
+        )
+
+        await provider.complete("llama3", [], tools=None)
+
+        _, kwargs = mock_create.call_args
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_structured_completion(self, monkeypatch):
+        from pydantic import BaseModel
+
+        class Weather(BaseModel):
+            temperature: int
+            unit: str
+
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1"
+        )
+        mock_create = AsyncMock(
+            return_value=_fake_completion(
+                '{"temperature": 72, "unit": "F"}'
+            )
+        )
+        monkeypatch.setattr(
+            provider.client.chat.completions, "create",
+            mock_create,
+        )
+
+        result = await provider.structured_completion(
+            "llama3", [], Weather,
+        )
+
+        assert isinstance(result, Weather)
+        assert result.temperature == 72
+        assert result.unit == "F"
+
+        _, kwargs = mock_create.call_args
+        rf = kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Weather"
+        assert rf["json_schema"]["strict"] is True
+        assert rf["json_schema"]["schema"] == Weather.model_json_schema()
+
+
+# ---------------------------------------------------------------------------
+# LiteLLMProvider
+# ---------------------------------------------------------------------------
+
+class TestLiteLLMProvider:
+    def _make_provider(self, mock_acompletion, **kwargs):
+        """Create a LiteLLMProvider with a fake litellm module."""
+        fake_litellm = ModuleType("litellm")
+        fake_litellm.acompletion = mock_acompletion
+        provider = object.__new__(LiteLLMProvider)
+        provider._litellm = fake_litellm
+        provider.api_key = kwargs.get("api_key")
+        provider._kwargs = {
+            k: v for k, v in kwargs.items() if k != "api_key"
+        }
+        return provider
+
+    def test_import_error_without_litellm(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "litellm":
+                raise ImportError("No module named 'litellm'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError, match="LiteLLMProvider"):
+            LiteLLMProvider()
+
+    @pytest.mark.asyncio
+    async def test_complete_with_tools(self):
+        mock_acompletion = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        provider = self._make_provider(mock_acompletion)
+
+        tools = [{"type": "function", "function": {"name": "f"}}]
+        result = await provider.complete(
+            "anthropic/claude-sonnet-4-20250514", [], tools=tools,
+        )
+
+        mock_acompletion.assert_called_once()
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs["tools"] == tools
+        assert kwargs["tool_choice"] == "auto"
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_complete_without_tools(self):
+        mock_acompletion = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        provider = self._make_provider(mock_acompletion)
+
+        await provider.complete("gemini/gemini-2.0-flash", [])
+
+        _, kwargs = mock_acompletion.call_args
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+        assert "api_key" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_api_key_forwarded(self):
+        mock_acompletion = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        provider = self._make_provider(
+            mock_acompletion, api_key="sk-test",
+        )
+
+        await provider.complete("anthropic/claude-sonnet-4-20250514", [])
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs["api_key"] == "sk-test"
+
+    @pytest.mark.asyncio
+    async def test_extra_kwargs_forwarded(self):
+        mock_acompletion = AsyncMock(
+            return_value=_fake_completion("ok")
+        )
+        provider = self._make_provider(
+            mock_acompletion, timeout=30, max_retries=2,
+        )
+
+        await provider.complete("model", [])
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs["timeout"] == 30
+        assert kwargs["max_retries"] == 2
+
+    @pytest.mark.asyncio
+    async def test_structured_completion(self):
+        from pydantic import BaseModel
+
+        class Sentiment(BaseModel):
+            label: str
+            score: float
+
+        mock_acompletion = AsyncMock(
+            return_value=_fake_completion(
+                '{"label": "positive", "score": 0.95}'
+            )
+        )
+        provider = self._make_provider(
+            mock_acompletion, api_key="sk-test", timeout=60,
+        )
+
+        result = await provider.structured_completion(
+            "anthropic/claude-sonnet-4-20250514", [], Sentiment,
+        )
+
+        assert isinstance(result, Sentiment)
+        assert result.label == "positive"
+        assert result.score == 0.95
+
+        _, kwargs = mock_acompletion.call_args
+        rf = kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Sentiment"
+        assert rf["json_schema"]["strict"] is True
+        assert rf["json_schema"]["schema"] == (
+            Sentiment.model_json_schema()
+        )
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["timeout"] == 60

--- a/uv.lock
+++ b/uv.lock
@@ -952,6 +952,47 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1446,6 +1487,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1643,6 +1696,9 @@ examples = [
     { name = "sentence-transformers" },
     { name = "transformers" },
 ]
+litellm = [
+    { name = "litellm" },
+]
 local = [
     { name = "outlines" },
     { name = "vllm" },
@@ -1685,11 +1741,35 @@ examples = [
     { name = "sentence-transformers", specifier = ">=5.2.3" },
     { name = "transformers", specifier = ">=4.56.2" },
 ]
+litellm = [{ name = "litellm", specifier = ">=1.67.0" }]
 local = [
     { name = "outlines", specifier = ">=1.2.5" },
     { name = "vllm", specifier = ">=0.10.2" },
 ]
 modal = [{ name = "modal", specifier = ">=0.73.0" }]
+
+[[package]]
+name = "litellm"
+version = "1.81.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/0c/62a0fdc5adae6d205338f9239175aa6a93818e58b75cf000a9c7214a3d9f/litellm-1.81.15.tar.gz", hash = "sha256:a8a6277a53280762051c5818ebc76dd5f036368b9426c6f21795ae7f1ac6ebdc", size = 16597039, upload-time = "2026-02-24T06:52:50.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/fd/da11826dda0d332e360b9ead6c0c992d612ecb85b00df494823843cfcda3/litellm-1.81.15-py3-none-any.whl", hash = "sha256:2fa253658702509ce09fe0e172e5a47baaadf697fb0f784c7fd4ff665ae76ae1", size = 14682123, upload-time = "2026-02-24T06:52:48.084Z" },
+]
 
 [[package]]
 name = "llguidance"
@@ -4946,6 +5026,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/28/0ddab6c1237e3625e7763ff666806f31e5760bb36d18624135a6bb6e8643/zensical-0.0.24-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9eef82865a18b3ca4c3cd13e245dff09a865d1da3c861e2fc86eaa9253a90f02", size = 12818270, upload-time = "2026-02-26T09:43:37.749Z" },
     { url = "https://files.pythonhosted.org/packages/2a/93/d2cef3705d4434896feadffb5b3e44744ef9f1204bc41202c1b84a4eeef6/zensical-0.0.24-cp310-abi3-win32.whl", hash = "sha256:f4d0ff47d505c786a26c9332317aa3e9ad58d1382f55212a10dc5bafcca97864", size = 11857695, upload-time = "2026-02-26T09:43:39.906Z" },
     { url = "https://files.pythonhosted.org/packages/f1/26/9707587c0f6044dd1e1cc5bc3b9fa5fed81ce6c7bcdb09c21a9795e802d9/zensical-0.0.24-cp310-abi3-win_amd64.whl", hash = "sha256:e00a62cf04526dbed665e989b8f448eb976247f077a76dfdd84699ace4aa3ac3", size = 12057762, upload-time = "2026-02-26T09:43:42.627Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds two new ModelProvider subclasses to cover the long tail of LLM endpoints, plus a bug fix in existing providers.
	∙	OpenAICompatibleProvider — generic provider for any server with an OpenAI-compatible /chat/completions endpoint (Ollama, Together, Groq, Fireworks, LM Studio, TGI, etc.). Accepts a base_url and optional api_key. Uses json_schema response_format for structured output since most compat servers don’t implement the Responses API or beta.chat.completions.parse.
	∙	LiteLLMProvider — delegates to litellm.acompletion() to reach 100+ providers (Anthropic, Gemini, Cohere, Bedrock, Mistral, Azure). Lazy-imports litellm so it’s not a required dependency. Constructor **kwargs are forwarded to every call for provider-specific options.
	∙	tool_choice normalization — fixes a bug where VLLMProvider sent tool_choice="auto" unconditionally (even without tools, causing errors on some vLLM versions). Also makes OpenAIProvider and OpenRouter explicitly send tool_choice="auto" when tools are present, matching the ModalVLLMProvider pattern.


https://claude.ai/code/session_01HmRa11xVUjQWAVVrADmGnJ