### PR TITLE
Separate handoffs from tools into first-class explicit concept

### DIFF
--- a/src/lemurian/agent.py
+++ b/src/lemurian/agent.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 
 from lemurian.capability import Capability
+from lemurian.handoff import Handoff
 from lemurian.provider import ModelProvider
 from lemurian.tools import Tool
 
@@ -14,10 +15,12 @@ class Agent(BaseModel):
 
     Args:
         name: Unique name identifying this agent.
-        description: Short description used in the Swarm's handoff tool
+        description: Short description used in handoff tool descriptions
             to help the LLM choose which agent to hand off to.
         system_prompt: System prompt injected by the Runner at call time.
         tools: List of Tool objects available to this agent.
+        handoffs: List of Handoff objects declaring which agents this
+            agent can transfer to.  Use the ``handoff()`` factory.
         capabilities: List of Capability instances whose tools are
             merged into this agent's tool registry at resolution time.
         model: Model identifier passed to the provider.
@@ -30,6 +33,7 @@ class Agent(BaseModel):
     description: str = ""
     system_prompt: str
     tools: list[Tool] = Field(default_factory=list)
+    handoffs: list[Handoff] = Field(default_factory=list)
     capabilities: list[Capability] = Field(default_factory=list)
     model: str
     provider: ModelProvider

--- a/src/lemurian/handoff.py
+++ b/src/lemurian/handoff.py
@@ -1,0 +1,92 @@
+import re
+from dataclasses import dataclass, field
+
+
+def _normalize_tool_name(name: str) -> str:
+    """Normalize an agent name into a valid tool-name string.
+
+    Lowercases, replaces whitespace/hyphens with underscores, strips
+    non-alphanumeric characters.  E.g. ``"Billing Support"`` becomes
+    ``"billing_support"``.
+    """
+    name = name.lower().strip()
+    name = re.sub(r"[\s\-]+", "_", name)
+    name = re.sub(r"[^a-z0-9_]", "", name)
+    return name
+
+
+@dataclass
+class Handoff:
+    """A declared transfer from one agent to another.
+
+    Converted to a tool schema for the LLM but never executed through
+    the tool pipeline.  The Runner classifies handoff tool calls by
+    name and returns immediately without executing any function.
+
+    Args:
+        tool_name: Tool name sent to the LLM (e.g. ``"transfer_to_billing"``).
+        tool_description: Description shown to the LLM.
+        target_agent: Name of the agent to hand off to.
+        input_json_schema: JSON schema for the tool parameters.
+    """
+
+    tool_name: str
+    tool_description: str
+    target_agent: str
+    input_json_schema: dict = field(default_factory=lambda: {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": (
+                    "Context and instructions for the next agent"
+                ),
+            },
+        },
+        "required": ["message"],
+    })
+
+    def tool_schema(self) -> dict:
+        """Return an OpenAI-compatible function tool schema."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.tool_name,
+                "description": self.tool_description,
+                "parameters": self.input_json_schema,
+            },
+        }
+
+
+@dataclass
+class HandoffResult:
+    """Constructed by the Runner when it classifies a handoff tool call.
+
+    Not returned by a tool function — the Runner builds this from the
+    :class:`Handoff` metadata and the parsed tool-call arguments.
+
+    Args:
+        target_agent: Name of the agent to hand off to.
+        message: Context and instructions for the next agent.
+    """
+
+    target_agent: str
+    message: str
+
+
+def handoff(agent_name: str, description: str = "") -> Handoff:
+    """Create a :class:`Handoff` from an agent name and description.
+
+    Normalises the agent name to produce a valid tool name
+    (e.g. ``"Billing Support"`` → ``"transfer_to_billing_support"``).
+    """
+    normalized = _normalize_tool_name(agent_name)
+    return Handoff(
+        tool_name=f"transfer_to_{normalized}",
+        tool_description=(
+            f"Hand off to {agent_name}. {description}"
+            if description
+            else f"Hand off to {agent_name}."
+        ),
+        target_agent=agent_name,
+    )

--- a/src/lemurian/tools.py
+++ b/src/lemurian/tools.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import json
-from dataclasses import dataclass
 from typing import Any, Callable, get_type_hints
 
 from docstring_parser import parse as parse_docstring
@@ -38,22 +37,6 @@ class LLMRecoverableError(Exception):
                 )
             return db.get(user_id)
     """
-
-
-@dataclass
-class HandoffResult:
-    """Returned by a tool to signal an agent handoff.
-
-    When the Runner detects a HandoffResult as a tool's output, it
-    stops execution and returns control to the Swarm for agent switching.
-
-    Args:
-        target_agent: Name of the agent to hand off to.
-        message: Context and instructions for the next agent.
-    """
-
-    target_agent: str
-    message: str
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,7 @@ def make_agent(mock_provider):
     def _make(
         name="test_agent",
         tools=None,
+        handoffs=None,
         capabilities=None,
         system_prompt="You are helpful.",
         description="",
@@ -214,6 +215,7 @@ def make_agent(mock_provider):
             description=description,
             system_prompt=system_prompt,
             tools=tools or [],
+            handoffs=handoffs or [],
             capabilities=capabilities or [],
             model="mock-model",
             provider=provider or mock_provider,

--- a/tests/unit/test_handoff.py
+++ b/tests/unit/test_handoff.py
@@ -1,0 +1,119 @@
+from lemurian.handoff import (
+    Handoff,
+    HandoffResult,
+    _normalize_tool_name,
+    handoff,
+)
+
+
+class TestNormalizeToolName:
+    def test_lowercase(self):
+        assert _normalize_tool_name("Billing") == "billing"
+
+    def test_spaces_to_underscores(self):
+        assert (
+            _normalize_tool_name("Billing Support")
+            == "billing_support"
+        )
+
+    def test_hyphens_to_underscores(self):
+        assert (
+            _normalize_tool_name("billing-support")
+            == "billing_support"
+        )
+
+    def test_strips_special_chars(self):
+        assert (
+            _normalize_tool_name("billing@support!")
+            == "billingsupport"
+        )
+
+    def test_mixed_case_spaces_and_special(self):
+        assert (
+            _normalize_tool_name("  My Agent-Name! ")
+            == "my_agent_name"
+        )
+
+    def test_already_normalized(self):
+        assert _normalize_tool_name("billing") == "billing"
+
+    def test_multiple_spaces_collapse(self):
+        assert (
+            _normalize_tool_name("billing   support")
+            == "billing_support"
+        )
+
+
+class TestHandoffFactory:
+    def test_basic_creation(self):
+        h = handoff("billing", "Handles billing")
+
+        assert h.tool_name == "transfer_to_billing"
+        assert h.target_agent == "billing"
+        assert "billing" in h.tool_description
+        assert "Handles billing" in h.tool_description
+
+    def test_normalizes_name(self):
+        h = handoff("Billing Support", "Bills customers")
+
+        assert h.tool_name == "transfer_to_billing_support"
+        assert h.target_agent == "Billing Support"
+
+    def test_empty_description(self):
+        h = handoff("billing")
+
+        assert h.tool_description == "Hand off to billing."
+        assert "billing" in h.tool_description
+
+    def test_schema_has_message_param(self):
+        h = handoff("billing", "Bills")
+
+        schema = h.input_json_schema
+        assert "message" in schema["properties"]
+        assert "message" in schema["required"]
+
+
+class TestHandoffToolSchema:
+    def test_openai_format(self):
+        h = handoff("billing", "Bills customers")
+        schema = h.tool_schema()
+
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "transfer_to_billing"
+        assert "Bills customers" in schema["function"]["description"]
+        assert "properties" in schema["function"]["parameters"]
+
+    def test_custom_handoff_schema(self):
+        h = Handoff(
+            tool_name="route_to_vip",
+            tool_description="Route to VIP support",
+            target_agent="vip",
+            input_json_schema={
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Context",
+                    },
+                    "priority": {
+                        "type": "integer",
+                        "description": "Priority level",
+                    },
+                },
+                "required": ["message", "priority"],
+            },
+        )
+        schema = h.tool_schema()
+
+        assert schema["function"]["name"] == "route_to_vip"
+        params = schema["function"]["parameters"]
+        assert "priority" in params["properties"]
+
+
+class TestHandoffResult:
+    def test_basic_creation(self):
+        r = HandoffResult(
+            target_agent="billing", message="help"
+        )
+        assert r.target_agent == "billing"
+        assert r.message == "help"


### PR DESCRIPTION
Handoffs were previously disguised as regular tools — a single `handoff`
tool with an `agent_name` enum was injected into the agent's tool list,
executed through `Tool.__call__`, and detected via
`isinstance(result.output, HandoffResult)`. This conflated orchestration
with tool execution.

Following the OpenAI Agents SDK pattern, handoffs are now:
- Declared explicitly on agents via `Agent.handoffs: list[Handoff]`
- Given per-target tool names (`transfer_to_billing`, not `handoff`)
- Classified by name-map lookup before execution (never executed as functions)
- Defined in a dedicated `handoff.py` module with no circular imports

Key changes:
- New `src/lemurian/handoff.py`: Handoff, HandoffResult, handoff() factory,
  _normalize_tool_name()
- Agent: added `handoffs` field
- Runner: accepts `handoffs` param, classifies via name map before execution
- Swarm: replaced `_create_handoff_tool()` with `_resolve_handoffs()`,
  added collision validation between tool and handoff names
- tools.py: removed HandoffResult (moved to handoff.py)
- All tests updated for new explicit handoff API (165 tests passing)

https://claude.ai/code/session_0162uRDkDtBXsmtrX8jokdZy