### PR TITLE
Refactor tools to module-level with Tool.bind() for state injection

### DIFF
--- a/examples/knowledge_capability_example.py
+++ b/examples/knowledge_capability_example.py
@@ -1,8 +1,8 @@
 """Capability example: a SQLite-backed knowledge base.
 
 Demonstrates what makes a good Capability:
-- Encapsulates a real resource (SQLite database connection)
-- Provides a cohesive group of CRUD tools that close over the resource
+- Tools defined at module level with ``@tool`` and explicit resource parameters
+- Capability owns the resource (SQLite connection) and binds it into tools
 - Lifecycle hooks with real purpose (on_attach reports state, on_detach closes connection)
 - Fully self-contained — tools never reach into shared application state
 
@@ -53,6 +53,92 @@ def setup_tracing(service_name: str):
 
 
 # ---------------------------------------------------------------------------
+# Tools (standalone, accept a connection parameter)
+# ---------------------------------------------------------------------------
+
+
+@tool
+def store_note(conn: sqlite3.Connection, topic: str, content: str):
+    """Store a note under a topic. Creates the topic if it doesn't exist."""
+    conn.execute(
+        "INSERT OR IGNORE INTO topics (name) VALUES (?)", (topic,)
+    )
+    conn.execute(
+        """
+        INSERT INTO notes (topic_id, content)
+        VALUES ((SELECT id FROM topics WHERE name = ?), ?)
+        """,
+        (topic, content),
+    )
+    conn.commit()
+    return f"Stored note under '{topic}'."
+
+
+@tool
+def get_notes(conn: sqlite3.Connection, topic: str):
+    """List all notes under a specific topic."""
+    rows = conn.execute(
+        """
+        SELECT n.content, n.created_at
+        FROM notes n
+        JOIN topics t ON n.topic_id = t.id
+        WHERE t.name = ?
+        ORDER BY n.created_at
+        """,
+        (topic,),
+    ).fetchall()
+    if not rows:
+        return f"No notes found under '{topic}'."
+    lines = [f"  - {content} ({created_at})" for content, created_at in rows]
+    return f"Notes under '{topic}':\n" + "\n".join(lines)
+
+
+@tool
+def search_notes(conn: sqlite3.Connection, query: str):
+    """Search notes by keyword across all topics."""
+    rows = conn.execute(
+        """
+        SELECT t.name, n.content
+        FROM notes n
+        JOIN topics t ON n.topic_id = t.id
+        WHERE n.content LIKE ? OR t.name LIKE ?
+        ORDER BY t.name, n.created_at
+        """,
+        (f"%{query}%", f"%{query}%"),
+    ).fetchall()
+    if not rows:
+        return "No matching notes found."
+    return "\n".join(f"[{topic}] {content}" for topic, content in rows)
+
+
+@tool
+def list_topics(conn: sqlite3.Connection):
+    """List all topics with their note counts."""
+    rows = conn.execute(
+        """
+        SELECT t.name, COUNT(n.id) as count
+        FROM topics t
+        LEFT JOIN notes n ON n.topic_id = t.id
+        GROUP BY t.id
+        ORDER BY t.name
+        """
+    ).fetchall()
+    if not rows:
+        return "No topics yet."
+    return "\n".join(f"  {name} ({count} notes)" for name, count in rows)
+
+
+@tool
+def delete_topic(conn: sqlite3.Connection, topic: str):
+    """Delete a topic and all its notes."""
+    cursor = conn.execute("DELETE FROM topics WHERE name = ?", (topic,))
+    conn.commit()
+    if cursor.rowcount == 0:
+        return f"No topic found named '{topic}'."
+    return f"Deleted topic '{topic}' and all its notes."
+
+
+# ---------------------------------------------------------------------------
 # Capability: Knowledge Base (SQLite-backed)
 # ---------------------------------------------------------------------------
 
@@ -61,7 +147,7 @@ class KnowledgeBaseCapability(Capability):
 
     Owns a SQLite connection with two tables: ``topics`` (named categories)
     and ``notes`` (content entries that belong to a topic via foreign key).
-    All tools close over the connection — no shared application state needed.
+    Tools are defined at module level and bound to the connection here.
 
     Args:
         db_path: Path to the SQLite database file, or ":memory:" for
@@ -89,85 +175,13 @@ class KnowledgeBaseCapability(Capability):
         self._conn.commit()
 
     def tools(self) -> list[Tool]:
-        conn = self._conn
-
-        @tool
-        def store_note(topic: str, content: str):
-            """Store a note under a topic. Creates the topic if it doesn't exist."""
-            conn.execute(
-                "INSERT OR IGNORE INTO topics (name) VALUES (?)", (topic,)
-            )
-            conn.execute(
-                """
-                INSERT INTO notes (topic_id, content)
-                VALUES ((SELECT id FROM topics WHERE name = ?), ?)
-                """,
-                (topic, content),
-            )
-            conn.commit()
-            return f"Stored note under '{topic}'."
-
-        @tool
-        def get_notes(topic: str):
-            """List all notes under a specific topic."""
-            rows = conn.execute(
-                """
-                SELECT n.content, n.created_at
-                FROM notes n
-                JOIN topics t ON n.topic_id = t.id
-                WHERE t.name = ?
-                ORDER BY n.created_at
-                """,
-                (topic,),
-            ).fetchall()
-            if not rows:
-                return f"No notes found under '{topic}'."
-            lines = [f"  - {content} ({created_at})" for content, created_at in rows]
-            return f"Notes under '{topic}':\n" + "\n".join(lines)
-
-        @tool
-        def search_notes(query: str):
-            """Search notes by keyword across all topics."""
-            rows = conn.execute(
-                """
-                SELECT t.name, n.content
-                FROM notes n
-                JOIN topics t ON n.topic_id = t.id
-                WHERE n.content LIKE ? OR t.name LIKE ?
-                ORDER BY t.name, n.created_at
-                """,
-                (f"%{query}%", f"%{query}%"),
-            ).fetchall()
-            if not rows:
-                return "No matching notes found."
-            return "\n".join(f"[{topic}] {content}" for topic, content in rows)
-
-        @tool
-        def list_topics():
-            """List all topics with their note counts."""
-            rows = conn.execute(
-                """
-                SELECT t.name, COUNT(n.id) as count
-                FROM topics t
-                LEFT JOIN notes n ON n.topic_id = t.id
-                GROUP BY t.id
-                ORDER BY t.name
-                """
-            ).fetchall()
-            if not rows:
-                return "No topics yet."
-            return "\n".join(f"  {name} ({count} notes)" for name, count in rows)
-
-        @tool
-        def delete_topic(topic: str):
-            """Delete a topic and all its notes."""
-            cursor = conn.execute("DELETE FROM topics WHERE name = ?", (topic,))
-            conn.commit()
-            if cursor.rowcount == 0:
-                return f"No topic found named '{topic}'."
-            return f"Deleted topic '{topic}' and all its notes."
-
-        return [store_note, get_notes, search_notes, list_topics, delete_topic]
+        return [
+            store_note.bind(conn=self._conn),
+            get_notes.bind(conn=self._conn),
+            search_notes.bind(conn=self._conn),
+            list_topics.bind(conn=self._conn),
+            delete_topic.bind(conn=self._conn),
+        ]
 
     def on_attach(self, state: State) -> None:
         topics = self._conn.execute("SELECT COUNT(*) FROM topics").fetchone()[0]

--- a/examples/local_research_agent_example.py
+++ b/examples/local_research_agent_example.py
@@ -2,7 +2,9 @@
 
 Demonstrates:
 
-- Building a Capability with exact and semantic search over local files
+- Defining tools with ``@tool`` at module level (outside the Capability)
+
+- Wiring capability state into tools with ``Tool.bind()``
 
 - OpenTelemetry tracing with ConsoleSpanExporter
 
@@ -63,6 +65,112 @@ def setup_tracing(service_name: str):
     instrument()
 
 
+# ---------------------------------------------------------------------------
+# Tools (standalone, capability-agnostic)
+# ---------------------------------------------------------------------------
+
+
+@tool
+def exact_search_files(file_map: dict, keyword: str) -> list[str]:
+    """Search all files in our local knowledge base for an exact
+    keyword match. If the keyword is not found, returns nothing.
+    Collects filenames that can be loaded into memory using the
+    ``open_file`` tool.
+
+    Args:
+        file_map: Internal mapping of file names to file paths.
+        keyword: Keyword or topic to search the file system for
+            appearances.
+
+    Returns:
+        file_names: The names of files that contain the keyword.
+    """
+    file_names = []
+    for f_name, f_path in file_map.items():
+        with open(f_path, 'r') as f:
+            if keyword in f.read():
+                file_names.append(f_name)
+    return file_names
+
+
+@tool
+def semantic_search_files(
+        model: SentenceTransformer,
+        dim: int,
+        index_future: concurrent.futures.Future,
+        file_map: dict,
+        query: str,
+        k: int,
+        cutoff: float = 0.0,
+) -> list[str]:
+    """Searches vector embeddings of files in our local knowledge base
+    for a vector similarity match. Collects filenames that can be
+    loaded into memory using the ``open_file`` tool.
+
+    Args:
+        model: Sentence transformer model for encoding queries.
+        dim: Embedding dimension.
+        index_future: Future that resolves to the FAISS index.
+        file_map: Internal mapping of file names to file paths.
+        query: Search query for semantic search across files.
+        k: Number of results to return.
+        cutoff: Cutoff value for similarity search.
+            Defaults to 0, but can be set higher for more relevant
+            results.
+
+    Notes:
+        This tool is only useable if ``include_vectors = True`` when
+        the user set up the assistant.
+    """
+    if not index_future.done():
+        raise LLMRecoverableError(
+            "Vector index is still building. Use "
+            "``exact_search_files`` in the meantime."
+        )
+    index = index_future.result()
+    if not (cutoff >= 0.0 or cutoff < 1):
+        raise LLMRecoverableError(
+            "Cutoff must be within the range [0, 1)"
+        )
+    query_vector = model.encode(query)[None, :dim]
+    distances, indices = index.search(query_vector, k)
+    all_f_names = list(file_map.keys())
+    f_names = []
+    for d, i in zip(distances[0], indices[0]):
+        if d < cutoff:
+            continue
+        f_names.append(all_f_names[i])
+    return f_names
+
+
+@tool
+def open_file(file_map: dict, file_name: str) -> str:
+    """Open a file based on its file_name and read it into context.
+
+    Args:
+        file_map: Internal mapping of file names to file paths.
+        file_name: The name of the file in the internal mapping.
+
+    Returns:
+        content: Contents of the named file.
+    """
+    if file_name not in file_map:
+        raise LLMRecoverableError(
+            f"File '{file_name}' not found. Use ``exact_search_files`` "
+            "to find valid file names first."
+        )
+
+    with open(file_map[file_name], 'r') as f:
+        content = f.read()
+
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Capability (owns resources, binds state into tools)
+# ---------------------------------------------------------------------------
+
+
 class ResearchCapability(Capability):
     """
     Search tools and analysis for examining local files.
@@ -98,7 +206,7 @@ class ResearchCapability(Capability):
         filter_dir = [".DS_Store"]
         file_paths = []
         directories = [self.root]
-        
+
         while directories:
             curr_dir = directories.pop(0)
             if curr_dir.name in filter_dir:
@@ -131,7 +239,7 @@ class ResearchCapability(Capability):
 
     def initialize_vectors(self, model, dim: int):
         """
-        uses 
+        uses
         """
         index = faiss.IndexHNSWFlat(dim, 32)
         for _, f_path in self.file_map.items():
@@ -141,97 +249,21 @@ class ResearchCapability(Capability):
                 index.add(embedding[None, :dim])
         return index
 
-    def tools(self) -> list[Tool]: 
-        @tool
-        def exact_search_files(keyword: str) -> list[str]:
-            """Search all files in our local knowledge base for an exact
-            keyword match. If the keyword is not found, returns nothing.
-            Collects filenames that can be loaded into memory using the 
-            ``open_file`` tool.
-
-            Args:
-                keyword (str): Keyword or topic to search the file system for
-                    appearances.
-
-            Returns:
-                file_names (str): The names of files that contain the keyword.
-            """
-            file_names = []
-            for f_name, f_path in self.file_map.items():
-                with open(f_path, 'r') as f:
-                    if keyword in f.read():
-                        file_names.append(f_name)
-            return file_names
-
-        @tool
-        def semantic_search_files(
-                query: str,
-                k: int,
-                cutoff: float = 0.0
-        ) -> list[str]:
-            """Searches vector embeddings of files in our local knowledge base
-            for a vector similarity match. Collects filenames that can be
-            loaded into memory using the ``open_file`` tool.
-
-            Args:
-                query (str): Search query for semantic search across files.
-                k (int): Number of results to return.
-                cutoff (float, optional): Cutoff value for similarity search.
-                    Defaults to 0, but can be set higher for more relevant
-                    results.
-
-            Notes:
-                This tool is only useable if ``include_vectors = True`` when
-                the user set up the assistant.
-            """
-            if not self.include_vectors:
-                raise LLMRecoverableError(
-                    "Research agent was not created with "
-                    "``include_vectors = True``. If you want to use semantic"
-                    " search then that parameter has to be enabled. Default "
-                    "back to ``exact_search_files`` with appropriate keywords"
-                    " instead."
+    def tools(self) -> list[Tool]:
+        result = [
+            exact_search_files.bind(file_map=self.file_map),
+            open_file.bind(file_map=self.file_map),
+        ]
+        if self.include_vectors:
+            result.append(
+                semantic_search_files.bind(
+                    model=self.model,
+                    dim=self.dim,
+                    index_future=self._index_future,
+                    file_map=self.file_map,
                 )
-            if not self._index_future.done():
-                raise LLMRecoverableError(
-                    "Vector index is still building. Use "
-                    "``exact_search_files`` in the meantime."
-                )
-            index = self._index_future.result()
-            if not (cutoff >= 0.0 or cutoff < 1):
-                raise LLMRecoverableError(
-                    "Cutoff must be within the range [0, 1)"
-                )
-            query_vector = self.model.encode(query)[None, :self.dim]
-            distances, indices = index.search(query_vector, k)
-            all_f_names = list(self.file_map.keys())
-            f_names = []
-            for d, i in zip(distances[0], indices[0]):
-                if d < cutoff:
-                    continue
-                f_names.append(all_f_names[i])
-            return f_names
-
-        @tool
-        def open_file(file_name: str) -> str:
-            """Open a file based on its file_name and read it into context.
-
-            Args:
-                file_name (str): The name of the file in the internal mapping.
-
-            Returns:
-                content (str): Contents of the named file.
-            """
-            # check to confirm whether file is safe
-            if file_name not in self.file_map:
-                raise LLMRecoverableError("")
-
-            with open(self.file_map[file_name], 'r') as f:
-                content = f.read()
-
-            return content
-
-        return [exact_search_files, semantic_search_files, open_file]
+            )
+        return result
 
 
 async def main():


### PR DESCRIPTION
## Summary

This PR refactors the tool definition pattern to define tools at module level as standalone functions, then use `Tool.bind()` to wire capability state into them. This improves separation of concerns and makes tools more reusable and testable.

## Key Changes

- **Added `Tool.bind()` method** (`src/lemurian/tools.py`):
  - Implements partial application of tool parameters
  - Automatically removes bound parameters from the LLM-visible schema
  - Supports chaining: `tool.bind(a=1).bind(b=2)`
  - Preserves tool name, description, and async behavior

- **Refactored `knowledge_capabilities.py` example**:
  - Moved all tool definitions (`store_note`, `get_notes`, `search_notes`, `list_topics`, `delete_topic`) to module level
  - Tools now accept `conn: sqlite3.Connection` as an explicit parameter
  - `KnowledgeBaseCapability.tools()` now binds the connection: `store_note.bind(conn=self._conn)`
  - Updated docstring to reflect new pattern

- **Refactored `local_research_agent.py` example**:
  - Moved search and file tools (`exact_search_files`, `semantic_search_files`, `open_file`) to module level
  - Tools now accept resource parameters (`file_map`, `model`, `dim`, `index_future`) explicitly
  - `ResearchCapability.tools()` binds resources conditionally (e.g., only adds `semantic_search_files` if vectors enabled)
  - Improved docstrings with clearer parameter documentation

- **Added comprehensive tests** (`tests/unit/test_tools.py`):
  - Tests for schema parameter removal
  - Tests for required parameter list updates
  - Tests for name/description preservation
  - Tests for callable behavior with bound parameters
  - Tests for async function support
  - Tests for immutability of original tool
  - Tests for chained binding
  - Tests for context parameter handling

## Implementation Details

- `Tool.bind()` uses `functools.partial` to pre-fill parameters in the underlying function
- Schema modifications are deep-copied to avoid mutating the original tool
- Bound parameters are removed from both `properties` and `required` lists in the JSON schema
- The pattern enables capabilities to own resources while keeping tools capability-agnostic and reusable

https://claude.ai/code/session_01JZ43Rws6Sjv7VkuWX9hJcg